### PR TITLE
Switch app.close.io to api.close.com

### DIFF
--- a/Libraries/CloseIoDotNet/Rest/ClientFactories/RestClientFactory.cs
+++ b/Libraries/CloseIoDotNet/Rest/ClientFactories/RestClientFactory.cs
@@ -10,7 +10,7 @@
     public class RestClientFactory : IRestClientFactory
     {
         #region Constants
-        private const string BaseUrl = "https://app.close.io/api/v1/";
+        private const string BaseUrl = "https://api.close.com/api/v1/";
         #endregion
 
         #region Instance Variables


### PR DESCRIPTION
Hey MoreThanRewards -- 

Eric here from Close. As part of an ongoing domain migration, we're changing the base_url of API calls to api.close.com. This PR makes that change for your wrapper. 

app.close.io will continue to be supported, but is now deprecated. Thanks! 